### PR TITLE
Update Debian Ruby Rails Image to Ruby 3.2.1 Rails 7.0.4.2 Bundler 2.4.7

### DIFF
--- a/rails/debian/debian-11-ruby-3.2-rails-7.0.4/dev/Dockerfile
+++ b/rails/debian/debian-11-ruby-3.2-rails-7.0.4/dev/Dockerfile
@@ -2,11 +2,11 @@
 # ASSUMPTION: source is volume mounted
 # docker build --no-cache -t brianjbayer/debian-11-ruby-3.2-rails-7.0.4-dev .
 # docker run -it --rm -v $(pwd):/app -p 3000:3000 brianjbayer/debian-11-ruby-3.2-rails-7.0.4-dev
-ARG BASE_IMAGE=ruby:3.2.0-slim-bullseye
+ARG BASE_IMAGE=ruby:3.2.1-slim-bullseye
 FROM ${BASE_IMAGE}
 
-ARG BUNDLER_VER=2.4.5
-ARG RAILS_VER=7.0.4
+ARG BUNDLER_VER=2.4.7
+ARG RAILS_VER=7.0.4.2
 
 # Install Build Packages, Bundler, and rails
 ARG BUILD_PACKAGES='build-essential libpq-dev libsqlite3-dev'
@@ -14,6 +14,8 @@ RUN apt-get update \
   && apt-get -y dist-upgrade \
   && apt-get -y install ${BUILD_PACKAGES} \
   && rm -rf /var/lib/apt/lists/* \
+  # Update gem command to latest
+  && gem update --system \
   # install bundler and rails versions
   && gem install bundler:$BUNDLER_VER rails:$RAILS_VER
 


### PR DESCRIPTION
This changeset updates the Debian Ruby Rails image to...
- Ruby 3.2.1 (latest)
- Rails 7.0.4.2 (latest - to address Rack [CVE-2023-27530](https://discuss.rubyonrails.org/t/cve-2023-27530-possible-dos-vulnerability-in-multipart-mime-parsing/82388))
- Bundler 2.4.7 (latest)

It also adds a `RUN` command to update the Ruby `gem` utility to the latest version (`gem update --system`)

The built image was run and all updated versions were verified.  This machine image was tested in a sample Rails application. 