### PR TITLE
Update Debian Ruby Rails Image to Rails 7.0.4.3 Bundler 2.4.8

### DIFF
--- a/rails/debian/debian-11-ruby-3.2-rails-7.0.4/dev/Dockerfile
+++ b/rails/debian/debian-11-ruby-3.2-rails-7.0.4/dev/Dockerfile
@@ -5,8 +5,8 @@
 ARG BASE_IMAGE=ruby:3.2.1-slim-bullseye
 FROM ${BASE_IMAGE}
 
-ARG BUNDLER_VER=2.4.7
-ARG RAILS_VER=7.0.4.2
+ARG BUNDLER_VER=2.4.8
+ARG RAILS_VER=7.0.4.3
 
 # Install Build Packages, Bundler, and rails
 ARG BUILD_PACKAGES='build-essential libpq-dev libsqlite3-dev'


### PR DESCRIPTION
This changeset updates the Debian Ruby Rails image to...
- Rails 7.0.4.3 (latest - to address ActiveSupport [CVE-2023-28120](https://discuss.rubyonrails.org/t/cve-2023-28120-possible-xss-security-vulnerability-in-safebuffer-bytesplice/82469) and Rack [CVE-2023-27539](https://discuss.rubyonrails.org/t/cve-2023-27539-possible-denial-of-service-vulnerability-in-racks-header-parsing/82466))
- Bundler 2.4.8 (latest)

The built image was run and all updated versions were verified.  This machine image was tested in a sample Rails application. 